### PR TITLE
OS-26: DataHelper added and automatic support for HTTP 400 responses disabled

### DIFF
--- a/OpenImis.DB.SqlServer/DataHelper/DataHelper.cs
+++ b/OpenImis.DB.SqlServer/DataHelper/DataHelper.cs
@@ -1,0 +1,169 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+
+namespace OpenImis.DB.SqlServer.DataHelper
+{
+    public class DataHelper
+    {
+        private readonly string ConnectionString;
+
+        public int ReturnValue { get; set; }
+
+        public DataHelper(IConfiguration configuration)
+        {
+            ConnectionString = configuration["ConnectionStrings:IMISDatabase"];
+        }
+
+        public DataSet FillDataSet(string SQL, SqlParameter[] parameters, CommandType commandType)
+        {
+            DataSet ds = new DataSet();
+            var sqlConnection = new SqlConnection(ConnectionString);
+
+            SqlParameter returnParameter = new SqlParameter("@RV", SqlDbType.Int);
+            returnParameter.Direction = ParameterDirection.ReturnValue;
+
+            var command = new SqlCommand(SQL, sqlConnection)
+            {
+                CommandType = commandType
+            };
+
+            command.Parameters.Add(returnParameter);
+
+            var adapter = new SqlDataAdapter(command);
+            using (command)
+            {
+                if (parameters.Length > 0)
+                    command.Parameters.AddRange(parameters);
+                adapter.Fill(ds);
+            }
+
+            ReturnValue = int.Parse(returnParameter.Value.ToString());
+
+            return ds;
+        }
+
+        public DataTable GetDataTable(string SQL, SqlParameter[] parameters, CommandType commandType)
+        {
+            DataTable dt = new DataTable();
+            var sqlConnection = new SqlConnection(ConnectionString);
+            var command = new SqlCommand(SQL, sqlConnection)
+            {
+                CommandType = commandType
+            };
+
+            var adapter = new SqlDataAdapter(command);
+
+            using (command)
+            {
+                if (parameters.Length > 0)
+                    command.Parameters.AddRange(parameters);
+                adapter.Fill(dt);
+            }
+
+            return dt;
+        }
+
+        public void Execute(string SQL, SqlParameter[] parameters, CommandType commandType)
+        {
+            var sqlConnection = new SqlConnection(ConnectionString);
+
+            //if(SqlCommand.C)
+            // sqlConnection.Open
+            var command = new SqlCommand(SQL, sqlConnection)
+            {
+                CommandType = commandType
+            };
+
+            using (command)
+            {
+                if (command.Connection.State == 0)
+                {
+                    command.Connection.Open();
+
+                    if (parameters.Length > 0)
+                        command.Parameters.AddRange(parameters);
+
+                    command.ExecuteNonQuery();
+
+                    command.Connection.Close();
+                }
+            }
+        }
+
+        public ProcedureOutPut Procedure(string StoredProcedure, SqlParameter[] parameters, int tableIndex = 0)
+        {
+            DataSet dt = new DataSet();
+
+            SqlConnection sqlConnection = new SqlConnection(ConnectionString);
+            SqlCommand command = new SqlCommand();
+            //SqlDataReader reader;
+
+            SqlParameter returnParameter = new SqlParameter("@RV", SqlDbType.Int);
+            returnParameter.Direction = ParameterDirection.ReturnValue;
+
+            command.CommandText = StoredProcedure;
+            command.CommandType = CommandType.StoredProcedure;
+            command.Connection = sqlConnection;
+            command.Parameters.Add(returnParameter);
+
+            if (parameters.Length > 0)
+                command.Parameters.AddRange(parameters);
+
+            var adapter = new SqlDataAdapter(command);
+
+            using (command)
+            {
+                adapter.Fill(dt);
+            }
+
+            int rv = int.Parse(returnParameter.Value.ToString());
+            DataTable dat = new DataTable();
+
+            if (rv == 0)
+            {
+                dat = dt.Tables[tableIndex];
+            }
+
+            var output = new ProcedureOutPut
+            {
+                Code = rv,
+                Data = dat
+            };
+
+            return output;
+        }
+
+        public IList<SqlParameter> ExecProcedure(string StoredProcedure, SqlParameter[] parameters)
+        {
+            SqlConnection sqlConnection = new SqlConnection(ConnectionString);
+            SqlCommand command = new SqlCommand();
+
+            SqlParameter returnParameter = new SqlParameter("@RV", SqlDbType.Int);
+            returnParameter.Direction = ParameterDirection.ReturnValue;
+
+            command.CommandText = StoredProcedure;
+            command.CommandType = CommandType.StoredProcedure;
+            command.Connection = sqlConnection;
+            command.Parameters.Add(returnParameter);
+
+            if (parameters.Length > 0)
+                command.Parameters.AddRange(parameters);
+
+            sqlConnection.Open();
+
+            command.ExecuteNonQuery();
+
+            var rv = parameters.Where(x => x.Direction.Equals(ParameterDirection.Output) || x.Direction.Equals(ParameterDirection.ReturnValue)).ToList();
+            rv.Add(returnParameter);
+
+            sqlConnection.Close();
+
+            return rv;
+        }
+    }
+}

--- a/OpenImis.DB.SqlServer/DataHelper/ProcedureOutPut.cs
+++ b/OpenImis.DB.SqlServer/DataHelper/ProcedureOutPut.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Data;
+
+namespace OpenImis.DB.SqlServer.DataHelper
+{
+    public class ProcedureOutPut
+    {
+        public int Code { get; set; }
+        public DataTable Data { get; set; }
+    }
+}

--- a/OpenImis.RestApi/Startup.cs
+++ b/OpenImis.RestApi/Startup.cs
@@ -84,6 +84,11 @@ namespace OpenImis.RestApi
 				options.AddPolicy("AllowSpecificOrigin",
 					builder => builder.AllowAnyOrigin().AllowAnyMethod().AllowCredentials().AllowAnyHeader());
 			});
+
+            services.Configure<ApiBehaviorOptions>(options =>
+            {
+                options.SuppressModelStateInvalidFilter = true;
+            });
         }
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)


### PR DESCRIPTION
`DataHelper` has been added which is used to connect to the database in the case of procedures.
In the `Startup` file, I added a record that disables the automatic `HTTP 400` support.

TASK:
https://openimis.atlassian.net/browse/OS-26