### PR TITLE
OTC-29: A new endpoint for api has been added

### DIFF
--- a/ImisRestApi/ImisRestApi/Controllers/PaymentBaseController.cs
+++ b/ImisRestApi/ImisRestApi/Controllers/PaymentBaseController.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using ImisRestApi.Chanels.Payment.Models;
@@ -234,6 +236,30 @@ namespace ImisRestApi.Controllers
             {
                 return BadRequest(new ErrorResponseV2(){ error_occured = true, error_message = "Unknown Error Occured" });
             }
+        }
+
+        [Authorize(Roles = "PaymentAdd")]
+        [HttpPost]
+        [Route("api/ProvideReconciliationData")]
+        public virtual async Task<IActionResult> ProvideReconciliationData([FromBody]ReconciliationRequest model)
+        {
+            ValidationResult validation = new ValidationBase().ReconciliationData(model);
+
+            if (validation != ValidationResult.Success)
+            {
+                return BadRequest(new { error_occured = true, error_message = validation.ErrorMessage });
+            }
+
+            try
+            {
+                var response = await _payment.ProvideReconciliationData(model);
+                return Ok(response);
+            }
+            catch (Exception)
+            {
+                return BadRequest(new { error_occured = true, error_message = "Unknown Error Occured" });
+            }
+
         }
     }
 }

--- a/ImisRestApi/ImisRestApi/Logic/PaymentLogic.cs
+++ b/ImisRestApi/ImisRestApi/Logic/PaymentLogic.cs
@@ -12,6 +12,7 @@ using ImisRestApi.Models.Sms;
 using ImisRestApi.Chanels.Sms;
 using Newtonsoft.Json;
 using ImisRestApi.Models.Payment.Response;
+using System.Diagnostics;
 
 namespace ImisRestApi.Logic
 {
@@ -471,6 +472,20 @@ namespace ImisRestApi.Logic
 
             }
 
+        }
+
+        public async Task<ReconciliationMessage> ProvideReconciliationData(ReconciliationRequest model)
+        {
+            ImisPayment payment = new ImisPayment(_configuration, _hostingEnvironment);
+
+            var response = payment.ProvideReconciliationData(model);
+
+            ReconciliationMessage return_message = new ReconciliationMessage();
+
+            return_message.transactions = response;
+            return_message.error_occurred = false;
+
+            return return_message;
         }
     }
 }

--- a/ImisRestApi/ImisRestApi/Logic/ValidationBase.cs
+++ b/ImisRestApi/ImisRestApi/Logic/ValidationBase.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using ImisRestApi.Models.Payment;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -29,6 +31,43 @@ namespace ImisRestApi.Logic
                     return ValidationResult.Success;
                 else
                     return new ValidationResult("3:Not valid enrolment officer code");
+            }
+            return ValidationResult.Success;
+        }
+
+        public virtual ValidationResult ReconciliationData(ReconciliationRequest model)
+        {
+            if (model != null)
+            {
+                DateTime? startDate = null;
+                DateTime? endDate = null;
+                DateTime Odate;
+
+                // Conversion to the appropriate date format
+                if (DateTime.TryParseExact(model.date_from, "ddMMyyyy", System.Globalization.CultureInfo.InvariantCulture, DateTimeStyles.None, out Odate))
+                {
+                    startDate = DateTime.ParseExact(model.date_from, "ddMMyyyy", System.Globalization.CultureInfo.InvariantCulture);
+                }
+
+                if (DateTime.TryParseExact(model.date_to, "ddMMyyyy", System.Globalization.CultureInfo.InvariantCulture, DateTimeStyles.None, out Odate))
+                {
+                    endDate = DateTime.ParseExact(model.date_to, "ddMMyyyy", System.Globalization.CultureInfo.InvariantCulture);
+                }
+
+                // Validation
+                if (startDate == null || endDate == null)
+                {
+                    return new ValidationResult("1-Missing specification of the period");
+                }
+                else if (startDate > DateTime.Now && endDate > startDate)
+                {
+                    return new ValidationResult("3-The period is in the future");
+                }
+                else if (startDate >= endDate)
+                {
+                    return new ValidationResult("2-Beginning date follows closing date of the period");
+                }
+
             }
             return ValidationResult.Success;
         }

--- a/ImisRestApi/ImisRestApi/Models/Payment/ReconciliationItem.cs
+++ b/ImisRestApi/ImisRestApi/Models/Payment/ReconciliationItem.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ImisRestApi.Models.Payment
+{
+    public class ReconciliationItem
+    {
+        public string control_number { get; set; }
+        public string insurance_number { get; set; }
+        public string enrolment_officer_code { get; set; }
+        public string transaction_identification { get; set; }
+        public string receipt_identification { get; set; }
+        public double received_amount { get; set; }
+        public string received_date { get; set; }
+        public string payment_date { get; set; }
+        public string payment_origin { get; set; }
+        public string type_of_payment { get; set; }
+        public string language { get; set; }
+    }
+}

--- a/ImisRestApi/ImisRestApi/Models/Payment/ReconciliationRequest.cs
+++ b/ImisRestApi/ImisRestApi/Models/Payment/ReconciliationRequest.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace ImisRestApi.Models.Payment
+{
+    public class ReconciliationRequest
+    {
+        [Required]
+        [DataType(DataType.DateTime)]
+        public string date_from { get; set; }
+
+        [Required]
+        [DataType(DataType.DateTime)]
+        public string date_to { get; set; }
+    }
+}

--- a/ImisRestApi/ImisRestApi/Responses/ReconciliationMessage.cs
+++ b/ImisRestApi/ImisRestApi/Responses/ReconciliationMessage.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ImisRestApi.Responses
+{
+    public class ReconciliationMessage
+    {
+        public bool error_occurred { get; set; }
+        public object transactions { get; set; }
+    }
+}


### PR DESCRIPTION
I added new endpoint according to the documentation RFC 71v2.6.9.
The structure of the input and output data has been preserved as in the documentation.

JSON for testing in POSTMAN (http://localhost:63401/api/ProvideReconciliationData) :

- Success 200
```
{
     "date_from" : "10112000",
     "date_to" : "10112020"
}
```

- Missing specification of the period
```
{
     "date_from" : "",
     "date_to" : ""
}
```

- Beginning date follows closing date of the period
```
{
     "date_from" : "10112022",
     "date_to" : "10112020"
}
```

- The period is in the future
```
{
     "date_from" : "10112022",
     "date_to" : "10112023"
}
```