### PR TITLE
Added Escape/Sms strings to published api

### DIFF
--- a/ImisRestApi/ImisRestApi/ImisRestApi.csproj
+++ b/ImisRestApi/ImisRestApi/ImisRestApi.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Configurations>Debug;Release;CHFDebug;CHFRelease</Configurations>
+    <UserSecretsId>25c4613d-dca4-4a86-8ca9-9bf91873a550</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='CHFDebug|AnyCPU'">
@@ -39,6 +40,81 @@
     <Folder Include="wwwroot\Payments\" />
     <Folder Include="wwwroot\Reconciliations\" />
     <Folder Include="wwwroot\SentMessages\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\ControlNumberAssigned.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\ControlNumberAssignedV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\ControlNumberError.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\ControlNumberErrorV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\EnquireErrorSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\EnquireInformSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\PaidAndActivated.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\PaidAndNotActivated.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\PaidAndNotMatched.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\StringsSecondaryLanguage\PaidAndNotMatchedV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\CommissionInformSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\ControlNumberAssigned.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\ControlNumberAssignedV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\ControlNumberError.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\ControlNumberErrorV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\CtrlNumReqErrorSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\EnquireErrorSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\EnquireInformSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\PaidAndActivated.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\PaidAndNotActivated.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\PaidAndNotMatched.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\PaidAndNotMatchedV2.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\RenewErrorSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Escape\Sms\Strings\RenewInformSms.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ImisRestApi/ImisRestApi/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/ImisRestApi/ImisRestApi/Properties/PublishProfiles/FolderProfile.pubxml
@@ -13,7 +13,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
     <ProjectGuid>4eca9d05-7cb6-468a-af5a-1ab6954594ed</ProjectGuid>
-    <publishUrl>C:\Users\Hiren\Desktop\Rel_CHF</publishUrl>
+    <publishUrl>..\..\Rel_CHF</publishUrl>
     <DeleteExistingFiles>True</DeleteExistingFiles>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <SelfContained>true</SelfContained>


### PR DESCRIPTION
Strings from Escape/SMS are disappearing during publish. Changing the confuguration makes them persistent.