### PR TITLE
OTC-260: fix Reconcilation call still using config SPCODE

### DIFF
--- a/ImisRestApi/Data/ImisBasePayment.cs
+++ b/ImisRestApi/Data/ImisBasePayment.cs
@@ -806,7 +806,7 @@ namespace ImisRestApi.Data
         public List<String> GetProductsSPCode()
         {
 
-            var getProductsSPCodes = @"SELECT AccCodePremiums FROM tblProduct WHERE AccCodePremiums LIKE '%SP[0-9{3}]%' AND ValidityTo is NULL";
+            var getProductsSPCodes = @"SELECT AccCodePremiums FROM tblProduct WHERE AccCodePremiums LIKE 'SP[0-9][0-9][0-9]' AND ValidityTo is NULL";
 
             SqlParameter[] parameters = { };
 

--- a/ImisRestApi/Data/ImisBasePayment.cs
+++ b/ImisRestApi/Data/ImisBasePayment.cs
@@ -806,14 +806,14 @@ namespace ImisRestApi.Data
         public List<String> GetProductsSPCode()
         {
 
-            var getProductsSPCodes = @"SELECT AccCodePremiums FROM tblProduct WHERE AccCodePremiums LIKE 'SP[0-9][0-9][0-9]' AND ValidityTo is NULL";
+            var getProductsSPCodes = @"SELECT tblProduct.AccCodePremiums FROM tblProduct WHERE tblProduct.AccCodePremiums LIKE 'SP[0-9][0-9][0-9]' AND tblProduct.ValidityTo is NULL";
 
             SqlParameter[] parameters = { };
 
             try
             {
                 DataTable results = dh.GetDataTable(getProductsSPCodes, parameters, CommandType.Text);
-                List<String> productsCodes = null;
+                List<String> productsCodes = new List<String>();
                 if (results.Rows.Count > 0)
                 {
                     foreach (DataRow result in results.Rows) 

--- a/ImisRestApi/Data/ImisBasePayment.cs
+++ b/ImisRestApi/Data/ImisBasePayment.cs
@@ -802,5 +802,36 @@ namespace ImisRestApi.Data
 
             return result;
         }
+
+        public List<String> GetProductsSPCode()
+        {
+
+            var getProductsSPCodes = @"SELECT AccCodePremiums FROM tblProduct WHERE AccCodePremiums LIKE '%SP[0-9{3}]%' AND ValidityTo is NULL";
+
+            SqlParameter[] parameters = { };
+
+            try
+            {
+                DataTable results = dh.GetDataTable(getProductsSPCodes, parameters, CommandType.Text);
+                List<String> productsCodes = null;
+                if (results.Rows.Count > 0)
+                {
+                    foreach (DataRow result in results.Rows) 
+                    {
+                        if (!string.IsNullOrEmpty(Convert.ToString(result["AccCodePremiums"]))) 
+                        {
+                            productsCodes.Add(Convert.ToString(result["AccCodePremiums"]));
+                        }
+                    }
+                }
+
+                return productsCodes;
+            }
+            catch (Exception e)
+            {
+
+                throw e;
+            }
+        }
     }
 }

--- a/ImisRestApi/Escape/Payment/Controllers/PaymentController.cs
+++ b/ImisRestApi/Escape/Payment/Controllers/PaymentController.cs
@@ -146,26 +146,25 @@ namespace ImisRestApi.Controllers
         [Route("api/Reconciliation")]
         public IActionResult Reconciliation(int daysAgo)
         {
-            object done = new { resp = "" };
+            List<object> done = new List<object>();
             // Make loop for all product from database that have account follow SP[0-9]{3} and do the function for all sp codes
             var productsSPCodes = imisPayment.GetProductsSPCode();
-            if (productsSPCodes != null)
+            if (productsSPCodes.Count > 0)
             {
                 foreach (String productSPCode in productsSPCodes)
                 {
-                    done = imisPayment.RequestReconciliationReport(daysAgo, productSPCode);
+                    var result = imisPayment.RequestReconciliationReport(daysAgo, productSPCode);
+                    //check if we have done result - if no - then return 500
+                    System.Reflection.PropertyInfo pi = result.GetType().GetProperty("resp");
+                    done.Add(result);
                 }
             }
-            System.Reflection.PropertyInfo pi = done.GetType().GetProperty("resp");
-            //check if we have done result - if yes then we can output Ok, else NotFound
-            if ((String)(pi.GetValue(done, null)) != "")
+            else
             {
-                return Ok(done);
-            }
-            else 
-            {
+                //return not found - no sp codes to proceed 
                 return NotFound();
             }
+            return Ok(done);
         }
 
         [HttpPost]

--- a/ImisRestApi/Escape/Payment/Controllers/PaymentController.cs
+++ b/ImisRestApi/Escape/Payment/Controllers/PaymentController.cs
@@ -146,9 +146,26 @@ namespace ImisRestApi.Controllers
         [Route("api/Reconciliation")]
         public IActionResult Reconciliation(int daysAgo)
         {
-            var done = imisPayment.RequestReconciliationReport(daysAgo);
-
-            return Ok(done);
+            object done = new { resp = "" };
+            // Make loop for all product from database that have account follow SP[0-9]{3} and do the function for all sp codes
+            var productsSPCodes = imisPayment.GetProductsSPCode();
+            if (productsSPCodes != null)
+            {
+                foreach (String productSPCode in productsSPCodes)
+                {
+                    done = imisPayment.RequestReconciliationReport(daysAgo, productSPCode);
+                }
+            }
+            System.Reflection.PropertyInfo pi = done.GetType().GetProperty("resp");
+            //check if we have done result - if yes then we can output Ok, else NotFound
+            if ((String)(pi.GetValue(done, null)) != "")
+            {
+                return Ok(done);
+            }
+            else 
+            {
+                return NotFound();
+            }
         }
 
         [HttpPost]

--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -488,7 +488,7 @@ namespace ImisRestApi.Data
 
         }
 
-        public string SendReconcHttpRequest(String content)
+        public string SendReconcHttpRequest(String content, String productSPCode)
         {
 
             try
@@ -504,7 +504,7 @@ namespace ImisRestApi.Data
                 // Set the ContentLength property of the WebRequest. 
                 request.ContentLength = byteArray.Length;
                 //Set Custom Headers
-                request.Headers.Add("Gepg-Code", configuration["PaymentGateWay:GePG:SpCode"]);
+                request.Headers.Add("Gepg-Code", productSPCode);
                 request.Headers.Add("Gepg-Com", "default.sp.in");
                 // Get the request stream.  
                 Stream dataStream = request.GetRequestStream();

--- a/ImisRestApi/Escape/Payment/Data/ImisPayment.cs
+++ b/ImisRestApi/Escape/Payment/Data/ImisPayment.cs
@@ -29,7 +29,7 @@ namespace ImisRestApi.Data
         }
 
 #if CHF
-        public object RequestReconciliationReport(int daysAgo)
+        public object RequestReconciliationReport(int daysAgo, String productSPCode)
         {
             daysAgo = -1 * daysAgo;
 
@@ -39,7 +39,7 @@ namespace ImisRestApi.Data
 
             gepgSpReconcReq request = new gepgSpReconcReq();
             request.SpReconcReqId = Math.Abs(Guid.NewGuid().GetHashCode());//Convert.ToInt32(DateTime.UtcNow.Year.ToString() + DateTime.UtcNow.Month.ToString() + DateTime.UtcNow.Day.ToString());
-            request.SpCode = Configuration["PaymentGateWay:GePG:SpCode"];
+            request.SpCode = productSPCode;
             request.SpSysId = Configuration["PaymentGateWay:GePG:SystemId"];
             request.TnxDt = DateTime.Now.AddDays(daysAgo).ToString("yyyy-MM-dd");
             request.ReconcOpt = 1;
@@ -48,7 +48,7 @@ namespace ImisRestApi.Data
             string signature = gepg.GenerateSignature(requestString);
             var signedRequest = gepg.FinaliseSignedMsg(new ReconcRequest() { gepgSpReconcReq = request, gepgSignature = signature }, typeof(ReconcRequest));
 
-            var result = gepg.SendReconcHttpRequest(signedRequest);
+            var result = gepg.SendReconcHttpRequest(signedRequest, productSPCode);
 
             return new { reconcId = request.SpReconcReqId, resp = result };
 


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-260

In that PR I want to fix issue that @delcroip reported in that ticket on Friday with SPCode taken from configuration. I fixed this according to clues given by Patrick. 

1. Take all products from tbl Product with "SP[0-9{3}]" regex.
2. Iterate through all products in "Reconciliation" endpoint with such above condition 
3. RequestReconciliationReport - add new argument ProductSPCode.
4. SendReconcHttpRequest - add new argument ProductSPCode. 
5. Replace configuration["PaymentGateWay:GePG:SpCode"] into "ProductSPCode" in both "SendReconcHttpRequest " and "RequestReconciliationReport "