### PR TITLE
OTC-259: Use app config instead of hardcoded path for the cert

### DIFF
--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -37,10 +37,10 @@ namespace ImisRestApi.Data
         {
             configuration = Configuration;
 
-            PrivateStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgclientprivatekey.pfx";
-            PublicStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgclientpubliccertificate.pfx";
-            GepgPublicCertStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgpubliccertificatetoclients.pfx";
-            GepgPayCertStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgpaypubliccertificate.pfx";
+            PrivateStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PrivateStorePath"];
+            PublicStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PublicStorePath"];
+            GepgPublicCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPublicCertStorePath"];
+            GepgPayCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPayCertStorePath"];
         }
 
         public String CreateBill(IConfiguration Configuration, string OfficerCode,string PhoneNumber, string BillId, decimal ExpectedAmount, List<InsureeProduct> products)

--- a/ImisRestApi/appsettings.json
+++ b/ImisRestApi/appsettings.json
@@ -20,7 +20,11 @@
       "SpCode": "SP257",
       "SubSpCode": 1000,
       "Url": "http://154.118.230.18:80",
-      "GfsCode": [ "300106", "300107", "300109" ]
+      "GfsCode": [ "300106", "300107", "300109" ],
+      "PrivateStorePath": "\\Escape\\Payment\\Certificates\\gepgclientprivatekey.pfx",
+      "PublicStorePath": "\\Escape\\Payment\\Certificates\\gepgclientpubliccertificate.pfx",
+      "GepgPublicCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpubliccertificatetoclients.pfx",
+      "GepgPayCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpaypubliccertificate.pfx"
     }
   },
   "SmsGateWay": {


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-259

Debugger shows sth like this after and before my changes related to that ticket. 
Before changes:
![c#_path_settings](https://user-images.githubusercontent.com/52816247/117802615-fc500900-b255-11eb-82c5-3c08e20fe63e.PNG)
After changes:
![c#_path_settings_not_hardcoded](https://user-images.githubusercontent.com/52816247/117802607-f9edaf00-b255-11eb-9eb5-66f979b3f1bd.PNG)
