### PR TITLE
OTC-263: fix timeout issue on GetControlNumber

### DIFF
--- a/ImisRestApi/Data/ImisBasePayment.cs
+++ b/ImisRestApi/Data/ImisBasePayment.cs
@@ -76,13 +76,7 @@ namespace ImisRestApi.Data
             string ctrlNumber = null;
 
             // BEGIN Temporary Control Number Generator(Simulation For Testing Only)
-            var randomNumber = new Random().Next(100000, 999999);
-
-            //if(randomNumber%2 == 0)
-            //{
-            ctrlNumber = randomNumber.ToString();
-            //}
-            //END Temporary 
+            //var randomNumber = new Random().Next(100000, 999999);
 
             PostReqCNResponse response = new PostReqCNResponse() {
                

--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -26,7 +26,7 @@ namespace ImisRestApi.Data
         string GepgPublicCertStorePath = string.Empty;
         string GepgPayCertStorePath = string.Empty;
 
-        string CertPass = "HPSS1234";
+        string CertPass = "passpass";//HPSS1234
         string GepgCertPass = "gepg@2018";
 
         RSA rsaCrypto = null;

--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -26,8 +26,8 @@ namespace ImisRestApi.Data
         string GepgPublicCertStorePath = string.Empty;
         string GepgPayCertStorePath = string.Empty;
 
-        string CertPass = "passpass";//HPSS1234
-        string GepgCertPass = "gepg@2018";
+        string CertPass = string.Empty;
+        string GepgCertPass = string.Empty;
 
         RSA rsaCrypto = null;
         gepgBillSubReq newBill = null;
@@ -41,6 +41,9 @@ namespace ImisRestApi.Data
             PublicStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PublicStorePath"]);
             GepgPublicCertStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPublicCertStorePath"]);
             GepgPayCertStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPayCertStorePath"]);
+
+            CertPass = Configuration["PaymentGateWay:GePG:CertPass"];
+            GepgCertPass = Configuration["PaymentGateWay:GePG:GepgCertPass"]; 
         }
 
         public String CreateBill(IConfiguration Configuration, string OfficerCode,string PhoneNumber, string BillId, decimal ExpectedAmount, List<InsureeProduct> products)

--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -37,10 +37,10 @@ namespace ImisRestApi.Data
         {
             configuration = Configuration;
 
-            PrivateStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PrivateStorePath"];
-            PublicStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PublicStorePath"];
-            GepgPublicCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPublicCertStorePath"];
-            GepgPayCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPayCertStorePath"];
+            PrivateStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PrivateStorePath"]);
+            PublicStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PublicStorePath"]);
+            GepgPublicCertStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPublicCertStorePath"]);
+            GepgPayCertStorePath = Path.Combine(hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPayCertStorePath"]);
         }
 
         public String CreateBill(IConfiguration Configuration, string OfficerCode,string PhoneNumber, string BillId, decimal ExpectedAmount, List<InsureeProduct> products)

--- a/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
+++ b/ImisRestApi/Escape/Payment/Data/GepgUtility.cs
@@ -37,10 +37,10 @@ namespace ImisRestApi.Data
         {
             configuration = Configuration;
 
-            PrivateStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgclientprivatekey.pfx";
-            PublicStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgclientpubliccertificate.pfx";
-            GepgPublicCertStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgpubliccertificatetoclients.pfx";
-            GepgPayCertStorePath = hostingEnvironment.ContentRootPath + @"\Escape\Payment\Certificates\gepgpaypubliccertificate.pfx";
+            PrivateStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PrivateStorePath"];
+            PublicStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:PublicStorePath"];
+            GepgPublicCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPublicCertStorePath"];
+            GepgPayCertStorePath = hostingEnvironment.ContentRootPath + Configuration["PaymentGateWay:GePG:GepgPayCertStorePath"];
         }
 
         public String CreateBill(IConfiguration Configuration, string OfficerCode,string PhoneNumber, string BillId, decimal ExpectedAmount, List<InsureeProduct> products)

--- a/ImisRestApi/appsettings.json
+++ b/ImisRestApi/appsettings.json
@@ -20,7 +20,11 @@
       "SpCode": "SP257",
       "SubSpCode": 1000,
       "Url": "http://154.118.230.18:80",
-      "GfsCode": [ "300106", "300107", "300109" ]
+      "GfsCode": [ "300106", "300107", "300109" ],
+      "PrivateStorePath": "\\Escape\\Payment\\Certificates\\gepgclientprivatekey.pfx",
+      "PublicStorePath": "\\Escape\\Payment\\Certificates\\gepgclientpubliccertificate.pfx",
+      "GepgPublicCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpubliccertificatetoclients.pfx",
+      "GepgPayCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpaypubliccertificate.pfx"
     }
   },
   "SmsGateWay": {

--- a/ImisRestApi/appsettings.json
+++ b/ImisRestApi/appsettings.json
@@ -24,7 +24,9 @@
       "PrivateStorePath": "\\Escape\\Payment\\Certificates\\gepgclientprivatekey.pfx",
       "PublicStorePath": "\\Escape\\Payment\\Certificates\\gepgclientpubliccertificate.pfx",
       "GepgPublicCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpubliccertificatetoclients.pfx",
-      "GepgPayCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpaypubliccertificate.pfx"
+      "GepgPayCertStorePath": "\\Escape\\Payment\\Certificates\\gepgpaypubliccertificate.pfx",
+      "CertPass": "passpass",
+      "GepgCertPass": "gepg@2018"
     }
   },
   "SmsGateWay": {


### PR DESCRIPTION
related to TICKET: https://openimis.atlassian.net/browse/OTC-263

Changes:
1. change certPass hardcoded - current one caused issues because that one was realized to be wrong during testing.
2. include also some changes from ticket https://openimis.atlassian.net/browse/OTC-259 - move hardcoded path to appsettings.json - the only difference is using in that PR "Path.Combine". 
3. Removed generating control number Randomly in ImisBasePayment.cs "PostReqControlNumber".