### PR TITLE
OTC-301: Fix Timeout on api/family/{CHFID} endpoint

### DIFF
--- a/OpenImis.ModulesV2/InsureeModule/Repositories/FamilyRepository.cs
+++ b/OpenImis.ModulesV2/InsureeModule/Repositories/FamilyRepository.cs
@@ -44,14 +44,13 @@ namespace OpenImis.ModulesV2.InsureeModule.Repositories
                                        select UD.LocationId)
                                        .ToList();
 
-                    var familyId = (from item in locationIds
-                                    from I in imisContext.TblInsuree
+                    var familyId = (from I in imisContext.TblInsuree
                                     join F in imisContext.TblFamilies on I.FamilyId equals F.FamilyId
                                     join V in imisContext.TblVillages on F.LocationId equals V.VillageId
                                     join W in imisContext.TblWards on V.WardId equals W.WardId
                                     join D in imisContext.TblDistricts on W.DistrictId equals D.DistrictId
                                     where (I.Chfid == chfid
-                                        && D.DistrictId == item
+                                        && locationIds.Contains(D.DistrictId)
                                         && F.ValidityTo == null
                                         && I.ValidityTo == null
                                         && V.ValidityTo == null


### PR DESCRIPTION
Changes:
- Eliminated cross join in FamilyRepository in GetByCHFID method, which was making the endpoint unusable on a larger database (like on CHFIMIS backup the request time outs after 2 minutes of waiting). This change makes the request 2-3 seconds long.

[https://openimis.atlassian.net/browse/OTC-301](https://openimis.atlassian.net/browse/OTC-301)