### PR TITLE
OTC-334: Add “Vulnerability” field in Policies app

### DIFF
--- a/OpenImis.ModulesV3/InsureeModule/Models/EnrollFamilyModels/Insuree.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Models/EnrollFamilyModels/Insuree.cs
@@ -30,6 +30,6 @@ namespace OpenImis.ModulesV3.InsureeModule.Models.EnrollFamilyModels
         public string CurVillage { get; set; }
         public string isOffline { get; set; }
         public InsureeImage Picture { get; set; }
-        public bool Vulnerability { get; set; }
+        public string Vulnerability { get; set; }
     }
 }


### PR DESCRIPTION
Changes:
- Changed the type of the Vulnerability field in Enrolment model to string to fix the problem with casting the 0-1 value

[https://openimis.atlassian.net/browse/OTC-334](https://openimis.atlassian.net/browse/OTC-334)