### PR TITLE
OTC-349: Add endpoint for posting claims to APIv3

### DIFF
--- a/OpenImis.ModulesV3/ClaimModule/Logic/ClaimLogic.cs
+++ b/OpenImis.ModulesV3/ClaimModule/Logic/ClaimLogic.cs
@@ -42,7 +42,7 @@ namespace OpenImis.ModulesV3.ClaimModule.Logic
 
         public List<ClaimAdminModel> GetClaimAdministrators()
         {
-            List<ClaimAdminModel> response = new List<ClaimAdminModel>();
+            List<ClaimAdminModel> response;
 
             response = claimRepository.GetClaimAdministrators();
 
@@ -51,7 +51,7 @@ namespace OpenImis.ModulesV3.ClaimModule.Logic
 
         public List<TblControls> GetControls()
         {
-            List<TblControls> response = new List<TblControls>();
+            List<TblControls> response;
 
             response = claimRepository.GetControls();
 
@@ -63,6 +63,15 @@ namespace OpenImis.ModulesV3.ClaimModule.Logic
             PaymentLists response;
 
             response = claimRepository.GetPaymentLists(model);
+
+            return response;
+        }
+
+        public List<ClaimOutput> GetClaims(ClaimsModel model)
+        {
+            List<ClaimOutput> response;
+
+            response = claimRepository.GetClaims(model);
 
             return response;
         }

--- a/OpenImis.ModulesV3/Helpers/Extensions/StringExtensions.cs
+++ b/OpenImis.ModulesV3/Helpers/Extensions/StringExtensions.cs
@@ -6,7 +6,7 @@ namespace OpenImis.ModulesV3.PaymentModule.Helpers.Extensions
     {
         public static int? GetErrorNumber(this string str)
         {
-            if (String.IsNullOrEmpty(str))
+            if (string.IsNullOrEmpty(str))
             {
                 return null;
             }
@@ -27,7 +27,7 @@ namespace OpenImis.ModulesV3.PaymentModule.Helpers.Extensions
 
         public static string GetErrorMessage(this string str)
         {
-            if (String.IsNullOrEmpty(str))
+            if (string.IsNullOrEmpty(str))
             {
                 return str;
             }


### PR DESCRIPTION
Changes:
- Changed ClaimController to use `IImisModules` from modules V3 instead of old method
- Added `GetClaims` logic and repository methods
- Added `api/claim` endpoint for posting claims

[https://openimis.atlassian.net/browse/OTC-349](https://openimis.atlassian.net/browse/OTC-349)