### PR TITLE
OTC-356: ClaimController V3 does not allow unauthorised connections

### DIFF
--- a/OpenImis.RestApi/Controllers/V3/ClaimController.cs
+++ b/OpenImis.RestApi/Controllers/V3/ClaimController.cs
@@ -48,6 +48,7 @@ namespace OpenImis.RestApi.Controllers.V3
 
         [HttpPost]
         [Route("GetDiagnosesServicesItems")]
+        [AllowAnonymous]
         [ProducesResponseType(typeof(void), 200)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         public IActionResult GetDiagnosesServicesItems([FromBody]DsiInputModel model)
@@ -95,6 +96,7 @@ namespace OpenImis.RestApi.Controllers.V3
 
         [HttpGet]
         [Route("Claims/GetClaimAdmins")]
+        [AllowAnonymous]
         [ProducesResponseType(typeof(void), 200)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         public IActionResult ValidateClaimAdmin()
@@ -114,6 +116,7 @@ namespace OpenImis.RestApi.Controllers.V3
 
         [HttpGet]
         [Route("Claims/Controls")]
+        [AllowAnonymous]
         [ProducesResponseType(typeof(void), 200)]
         [ProducesResponseType(typeof(void), StatusCodes.Status401Unauthorized)]
         public IActionResult GetControls()


### PR DESCRIPTION
Changes:
- Allowed unauthorised connection for endpoints used in Claims app initialization

[https://openimis.atlassian.net/browse/OTC-356](https://openimis.atlassian.net/browse/OTC-356)