### PR TITLE
OTC-434: Fix policy renewal from renewal prompt

### DIFF
--- a/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
@@ -18,6 +18,7 @@ using System.Diagnostics;
 using System.Text;
 using OpenImis.ModulesV3.InsureeModule.Repositories;
 using OpenImis.DB.SqlServer.DataHelper;
+using OpenImis.ModulesV3.Utils;
 
 namespace OpenImis.ModulesV3.InsureeModule.Repositories
 {
@@ -190,8 +191,8 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
 
                 var hof = enrollFamily.Families.Select(x => x.HOFCHFID).FirstOrDefault();
 
-                var FileName = string.Format("{0}_{1}_{2}.xml", hof, officerId.ToString(), DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss"));
-                var JsonFileName = string.Format("{0}_{1}_{2}.json", hof, officerId.ToString(), DateTime.Now.ToString("dd-MM-yyyy HH-mm-ss"));
+                var FileName = string.Format("{0}_{1}_{2}.xml", hof, officerId.ToString(), DateTime.Now.ToString(DateTimeFormats.FileNameDateTimeFormat));
+                var JsonFileName = string.Format("{0}_{1}_{2}.json", hof, officerId.ToString(), DateTime.Now.ToString(DateTimeFormats.FileNameDateTimeFormat));
 
                 var xmldoc = new XmlDocument();
                 xmldoc.InnerXml = XML;

--- a/OpenImis.ModulesV3/PolicyModule/Repositories/PolicyRenewalRepository.cs
+++ b/OpenImis.ModulesV3/PolicyModule/Repositories/PolicyRenewalRepository.cs
@@ -14,6 +14,7 @@ using System.Xml;
 using System;
 using System.Diagnostics;
 using OpenImis.ePayment.Data;
+using OpenImis.ModulesV3.Utils;
 
 namespace OpenImis.ModulesV3.PolicyModule.Repositories
 {
@@ -105,7 +106,7 @@ namespace OpenImis.ModulesV3.PolicyModule.Repositories
                 var fromPhoneRenewalDir = _configuration["AppSettings:FromPhone_Renewal"] + Path.DirectorySeparatorChar;
                 var fromPhoneRenewalRejectedDir = _configuration["AppSettings:FromPhone_Renewal_Rejected"] + Path.DirectorySeparatorChar;
 
-                var fileName = "RenPol_" + policy.Date.ToString() + "_" + policy.CHFID + "_" + policy.ReceiptNo + ".xml";
+                var fileName = "RenPol_" + policy.Date.ToString(DateTimeFormats.FileNameDateTimeFormat) + "_" + policy.CHFID + "_" + policy.ReceiptNo + ".xml";
 
                 var xmldoc = new XmlDocument();
                 xmldoc.InnerXml = XML;

--- a/OpenImis.ModulesV3/Utils/DateTimeSerializers.cs
+++ b/OpenImis.ModulesV3/Utils/DateTimeSerializers.cs
@@ -10,7 +10,10 @@ namespace OpenImis.ModulesV3.Utils
     public static class DateTimeFormats
     {
         public static CultureInfo cultureInfo = CultureInfo.InvariantCulture;
-        public const string IsoDateOnlyFormat = "yyyy-MM-dd";
+        public const string IsoDateFormat = "yyyy-MM-dd";
+        public const string IsoDateTimeFormat = "yyyy-MM-ddTHH:mm:ss";
+        public const string FileNameDateTimeFormat = "yyyy-MM-ddTHH-mm-ss";
+
     }
 
     public class CustomFormatDatetimeSerializer : JsonConverter<DateTime>
@@ -35,7 +38,7 @@ namespace OpenImis.ModulesV3.Utils
 
     public class IsoDateOnlyDatetimeSerializer : CustomFormatDatetimeSerializer
     {
-        public IsoDateOnlyDatetimeSerializer() : base(DateTimeFormats.IsoDateOnlyFormat)
+        public IsoDateOnlyDatetimeSerializer() : base(DateTimeFormats.IsoDateFormat)
         {
         }
     }
@@ -52,7 +55,7 @@ namespace OpenImis.ModulesV3.Utils
             DateTime dt;
 
             if (DateTime.TryParse(data, out dt))
-                base.WriteRaw(dt.ToString(DateTimeFormats.IsoDateOnlyFormat, DateTimeFormats.cultureInfo));
+                base.WriteRaw(dt.ToString(DateTimeFormats.IsoDateFormat, DateTimeFormats.cultureInfo));
             else
                 base.WriteRaw(data);
         }


### PR DESCRIPTION
Changes:
- Adjusted `Datetime` format used to save enrolment and policy renewal XML files. Current format does not contain colons and allow files to be saved successfully.

[https://openimis.atlassian.net/browse/OTC-434](https://openimis.atlassian.net/browse/OTC-434)