### PR TITLE
OTC-389: MV IMIS Claims: Enquiry function doesn't provide photo and personal data

### DIFF
--- a/OpenImis.ModulesV3/ClaimModule/Data/ImisClaims.cs
+++ b/OpenImis.ModulesV3/ClaimModule/Data/ImisClaims.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json;
 using OpenImis.DB.SqlServer.DataHelper;
 using OpenImis.ModulesV3.ClaimModule.Models;
+using OpenImis.ModulesV3.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -171,15 +172,15 @@ namespace OpenImis.ModulesV3.ClaimModule.Data
                                                                     patient_name = dr["patient_name"].ToStringWithDBNull(),
                                                                     main_dg = dr["main_dg"].ToStringWithDBNull(),
                                                                     claim_number = dr["claim_number"].ToStringWithDBNull(),
-                                                                    date_claimed = DateTime.Parse(dr["date_claimed"].ToStringWithDBNull()),
-                                                                    visit_date_from = DateTime.Parse(dr["visit_date_from"].ToStringWithDBNull()),
+                                                                    date_claimed = dr["date_claimed"].ToString().ToNullableDatetime(),
+                                                                    visit_date_from = dr["visit_date_from"].ToString().ToNullableDatetime(),
                                                                     visit_type = dr["visit_type"].ToStringWithDBNull(),
                                                                     claim_status = dr["claim_status"].ToStringWithDBNull(),
                                                                     sec_dg_1 = dr["sec_dg_1"].ToStringWithDBNull(),
                                                                     sec_dg_2 = dr["sec_dg_2"].ToStringWithDBNull(),
                                                                     sec_dg_3 = dr["sec_dg_3"].ToStringWithDBNull(),
                                                                     sec_dg_4 = dr["sec_dg_4"].ToStringWithDBNull(),
-                                                                    visit_date_to = DateTime.Parse(dr["visit_date_to"].ToStringWithDBNull()),
+                                                                    visit_date_to = dr["visit_date_to"].ToString().ToNullableDatetime(),
                                                                     claimed = dr["claimed"].ToString().ParseNullableDecimal(),
                                                                     approved = dr["approved"].ToString().ParseNullableDecimal(),
                                                                     adjusted = dr["adjusted"].ToString().ParseNullableDecimal(),

--- a/OpenImis.ModulesV3/ClaimModule/Repositories/ClaimRepository.cs
+++ b/OpenImis.ModulesV3/ClaimModule/Repositories/ClaimRepository.cs
@@ -102,11 +102,11 @@ namespace OpenImis.ModulesV3.ClaimModule.Repositories
                         RV = (int)returnParameter.Value;
                         bool? isClaimRejected = claimRejectedParameter.Value as bool?;
 
-                        if ((RV == 0) && (isClaimRejected == false))
+                        if ((RV == 0) && (isClaimRejected == false || isClaimRejected == null))
                         {
                              RV = 0;
                         }
-                        else if (RV == 0 && (isClaimRejected == true || isClaimRejected == null))
+                        else if (RV == 0 && (isClaimRejected == true))
                         {
                             if (File.Exists(fromPhoneClaimDir + fileName) && !File.Exists(fromPhoneClaimRejectedDir + fileName))
                             {
@@ -338,15 +338,15 @@ namespace OpenImis.ModulesV3.ClaimModule.Repositories
                                                                 patient_name = dr["patient_name"].ToStringWithDBNull(),
                                                                 main_dg = dr["main_dg"].ToStringWithDBNull(),
                                                                 claim_number = dr["claim_number"].ToStringWithDBNull(),
-                                                                date_claimed = DateTime.Parse(dr["date_claimed"].ToStringWithDBNull()),
-                                                                visit_date_from = DateTime.Parse(dr["visit_date_from"].ToStringWithDBNull()),
+                                                                date_claimed = dr["date_claimed"].ToString().ToNullableDatetime(),
+                                                                visit_date_from = dr["visit_date_from"].ToString().ToNullableDatetime(),
                                                                 visit_type = dr["visit_type"].ToStringWithDBNull(),
                                                                 claim_status = dr["claim_status"].ToStringWithDBNull(),
                                                                 sec_dg_1 = dr["sec_dg_1"].ToStringWithDBNull(),
                                                                 sec_dg_2 = dr["sec_dg_2"].ToStringWithDBNull(),
                                                                 sec_dg_3 = dr["sec_dg_3"].ToStringWithDBNull(),
                                                                 sec_dg_4 = dr["sec_dg_4"].ToStringWithDBNull(),
-                                                                visit_date_to = DateTime.Parse(dr["visit_date_to"].ToStringWithDBNull()),
+                                                                visit_date_to = dr["visit_date_to"].ToString().ToNullableDatetime(),
                                                                 claimed = dr["claimed"].ToString().ParseNullableDecimal(),
                                                                 approved = dr["approved"].ToString().ParseNullableDecimal(),
                                                                 adjusted = dr["adjusted"].ToString().ParseNullableDecimal(),

--- a/OpenImis.ModulesV3/Helpers/Extensions.cs
+++ b/OpenImis.ModulesV3/Helpers/Extensions.cs
@@ -48,5 +48,12 @@ namespace OpenImis.ModulesV3.Helpers
             if (float.TryParse(s, out f)) return f;
             return null;
         }
+
+        public static DateTime? ToNullableDatetime(this string s)
+        {
+            DateTime d;
+            if (DateTime.TryParse(s, out d)) return d;
+            return null;
+        }
     }
 }

--- a/OpenImis.ModulesV3/InsureeModule/Logic/InsureeLogic.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Logic/InsureeLogic.cs
@@ -25,7 +25,10 @@ namespace OpenImis.ModulesV3.InsureeModule.Logic
 
             response = insureeRepository.GetEnquire(chfid);
 
-            response.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(_configuration.GetValue<string>("AppSettings:UpdatedFolder"), response.PhotoPath);
+            if (response != null)
+            {
+                response.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(_configuration.GetValue<string>("AppSettings:UpdatedFolder"), response.PhotoPath);
+            }
 
             return response;
         }

--- a/OpenImis.ModulesV3/InsureeModule/Models/DetailModel.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Models/DetailModel.cs
@@ -10,7 +10,7 @@ namespace OpenImis.ModulesV3.InsureeModule.Models
     {
         public string ProductName { get; set; }
         [JsonConverter(typeof(IsoDateSerializer))]
-        public DateTime ExpiryDate { get; set; }
+        public DateTime? ExpiryDate { get; set; }
         public string Status { get; set; }
         public float? DedType { get; set; }
         public decimal? Ded1 { get; set; }
@@ -32,6 +32,6 @@ namespace OpenImis.ModulesV3.InsureeModule.Models
         public decimal? TotalVisitsLeft { get; set; }
         public decimal? PolicyValue { get; set; }
         [JsonConverter(typeof(IsoDateSerializer))]
-        public DateTime EffectiveDate { get; set; }
+        public DateTime? EffectiveDate { get; set; }
     }
 }

--- a/OpenImis.ModulesV3/InsureeModule/Models/GetInsureeModel.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Models/GetInsureeModel.cs
@@ -12,7 +12,7 @@ namespace OpenImis.ModulesV3.InsureeModule.Models
         public string PhotoPath { get; set; }
         public string InsureeName { get; set; }
         [JsonConverter(typeof(IsoDateSerializer))]
-        public DateTime DOB { get; set; }
+        public DateTime? DOB { get; set; }
         public string Gender { get; set; }
         public string PhotoBase64 { get; set; }
     }

--- a/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
@@ -24,8 +24,8 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
 
         public GetEnquireModel GetEnquire(string chfid)
         {
-            GetEnquireModel response = new GetEnquireModel();
-            List<DetailModel> details = new List<DetailModel>();
+            GetEnquireModel response = null;
+            List<DetailModel> details = null;
 
             using (var imisContext = new ImisDB())
             {
@@ -48,20 +48,19 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                     {
                         do
                         {
-                            bool firstValue = true;
                             while (reader.Read())
                             {
-                                if (firstValue)
+                                if (response == null)
                                 {
+                                    response = new GetEnquireModel();
+                                    details = new List<DetailModel>();
+
                                     response.InsureeName = string.Join(' ', reader["OtherNames"].ToString()) + ' ' + reader["LastName"].ToString();
                                     response.CHFID = reader["CHFID"].ToString();
                                     response.PhotoPath = reader["PhotoPath"].ToString();
-                                    response.DOB = DateTime.Parse(reader["DOB"].ToString());
+                                    response.DOB = reader["DOB"].ToString().ToNullableDatetime();
                                     response.Gender = reader["Gender"].ToString();
-
-                                    firstValue = false;
                                 }
-
 
                                 details.Add(new DetailModel
                                 {
@@ -77,10 +76,10 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                                     TotalSurgeriesLeft = reader["TotalSurgeriesLeft"].ToString().ToNullableDecimal(),
                                     TotalVisitsLeft = reader["TotalVisitsLeft"].ToString().ToNullableDecimal(),
                                     PolicyValue = reader["PolicyValue"].ToString().ToNullableDecimal(),
-                                    EffectiveDate = DateTime.Parse(reader["EffectiveDate"].ToString()),
+                                    EffectiveDate = reader["EffectiveDate"].ToString().ToNullableDatetime(),
                                     ProductCode = reader["ProductCode"].ToString(),
                                     ProductName = reader["ProductName"].ToString(),
-                                    ExpiryDate = DateTime.Parse(reader["ExpiryDate"].ToString()),
+                                    ExpiryDate = reader["ExpiryDate"].ToString().ToNullableDatetime(),
                                     Status = reader["Status"].ToString(),
                                     DedType = reader["DedType"].ToString().ToNullableFloat(),
                                     Ded1 = reader["Ded1"].ToString().ToNullableDecimal(),
@@ -94,7 +93,10 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                 }
             }
 
-            response.Details = details;
+            if (response != null)
+            {
+                response.Details = details;
+            }
 
             return response;
         }


### PR DESCRIPTION
Changes:
- Changed datetime parsing to allow for `NULL` dates
- Fixed enquiry to return `404` if insuree is not found

[https://openimis.atlassian.net/browse/OTC-389](https://openimis.atlassian.net/browse/OTC-389)