### PR TITLE
Removed redundant FamilySMS join from FamilyRepisitory.GetByCHFID

### DIFF
--- a/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
@@ -66,7 +66,6 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                 response = imisContext.TblInsuree
                                     .Where(i => i.ValidityTo == null && i.FamilyId == familyId)
                                     .Join(imisContext.TblFamilies, i => i.FamilyId, f => f.FamilyId, (i, f) => f)
-                                    .Join(imisContext.TblFamilySMS, f => f.FamilyId, fsms => fsms.FamilyId, (f, fsms) => f)
                                     .Where(f => f.ValidityTo == null)
                                     .Include(f => f.TblInsuree)
                                         .ThenInclude(f => f.Photo)


### PR DESCRIPTION
Changes:
- Removed redundant `tblFamilySMS` join effectively changing `inner join tblFamilySMS` to `left join tblFamilySMS`