### PR TITLE
OTC-495: Fetch CN for EOs, numbers to be requested needs to exclude statuses except 1,2 and 3

### DIFF
--- a/OpenImis.ePayment/Escape/Payment/Data/ImisPayment.cs
+++ b/OpenImis.ePayment/Escape/Payment/Data/ImisPayment.cs
@@ -552,6 +552,7 @@ namespace OpenImis.ePayment.Data
 	                        AND P.ValidityTo IS NULL
 	                        AND PD.ProductCode = @ProductCode
 	                        AND P.OfficerCode IS NULL
+                            AND ISNULL(P.PaymentStatus, 0) IN (0, 1, 2, 3)
                         )
                         SELECT CASE WHEN Last3MonthsEnrollment > ControlNumbersLeft THEN Last3MonthsEnrollment - ControlNumbersLeft  ELSE 0 END NeedToRequest
                         FROM RemainingCNs, TotalProductUsage";


### PR DESCRIPTION
Changed the ControlNumberToBeRequested query and included only with the payment status 1,2 and 3

https://openimis.atlassian.net/browse/OTC-495