### PR TITLE
OTC-565: MemberCount type changed from int to short

### DIFF
--- a/OpenImis.DB.SqlServer/TblProduct.cs
+++ b/OpenImis.DB.SqlServer/TblProduct.cs
@@ -27,7 +27,7 @@ namespace OpenImis.DB.SqlServer
         public DateTime DateTo { get; set; }
         public int? ConversionProdId { get; set; }
         public decimal LumpSum { get; set; }
-        public int MemberCount { get; set; }
+        public short MemberCount { get; set; }
         public decimal? PremiumAdult { get; set; }
         public decimal? PremiumChild { get; set; }
         public decimal? DedInsuree { get; set; }


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-565

Changes:
- Changed type of MemberCount from int to short in RestApi to reflect structure of the DB.