### PR TITLE
OTC-565: Hotfix - change reversed - type changed from short to int.

### DIFF
--- a/OpenImis.DB.SqlServer/TblProduct.cs
+++ b/OpenImis.DB.SqlServer/TblProduct.cs
@@ -27,7 +27,7 @@ namespace OpenImis.DB.SqlServer
         public DateTime DateTo { get; set; }
         public int? ConversionProdId { get; set; }
         public decimal LumpSum { get; set; }
-        public short MemberCount { get; set; }
+        public int MemberCount { get; set; }
         public decimal? PremiumAdult { get; set; }
         public decimal? PremiumChild { get; set; }
         public decimal? DedInsuree { get; set; }


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-565

Hotfix - previous change reversed, as it was merged by accident.
Changes:
-MemberCount type changed back to int from short.