### PR TITLE
OTC-589: Reading the request body timed out due to data arriving too slowly

### DIFF
--- a/OpenImis.RestApi/Program.cs
+++ b/OpenImis.RestApi/Program.cs
@@ -35,7 +35,11 @@ namespace OpenImis.RestApi
         public static IWebHostBuilder GetWebHostBuilder(string appRootPath, string[] args)
         {
             var webHostBuilder = new WebHostBuilder()
-                .UseKestrel()
+                .UseKestrel(options =>
+                {
+                    options.Limits.MinRequestBodyDataRate =
+                    new Microsoft.AspNetCore.Server.Kestrel.Core.MinDataRate(bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(15));
+                })
                 .UseContentRoot(appRootPath)
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
@@ -54,7 +58,7 @@ namespace OpenImis.RestApi
 #if CHF
                     config.AddJsonFile($"{path}appsettings.CHF.json", optional: false, reloadOnChange: true);
 #endif
-                    config.AddJsonFile($"{path}openImisModules.json", optional: true, reloadOnChange: true);
+                    config.AddJsonFile($"openImisModules.json", optional: true, reloadOnChange: true);
                 })
                 .UseStartup<Startup>();
 


### PR DESCRIPTION
Set the minimum data rate to 100 with the grace period set to 15 seconds.