### PR TITLE
OTC-598: Error: System.IO.IOException: Cannot create a file when that file already exists

### DIFF
--- a/OpenImis.ModulesV3/PolicyModule/Repositories/PolicyRenewalRepository.cs
+++ b/OpenImis.ModulesV3/PolicyModule/Repositories/PolicyRenewalRepository.cs
@@ -155,7 +155,7 @@ namespace OpenImis.ModulesV3.PolicyModule.Repositories
                     int tempRV = (int)returnParameter.Value;
                     bool moveToRejected = false;
 
-                    switch (tempRV) 
+                    switch (tempRV)
                     {
                         case 0:
                             RV = (int)Errors.Renewal.Accepted;
@@ -181,12 +181,17 @@ namespace OpenImis.ModulesV3.PolicyModule.Repositories
                             break;
                     }
 
-                    if(moveToRejected)
+                    if (moveToRejected)
                     {
+                        // Check if the file already exists in the rejected folder
+                        // If yes then delete it otherwise it will throw and exception
+                        if (File.Exists(fromPhoneRenewalRejectedDir + fileName))
+                            File.Delete(fromPhoneRenewalRejectedDir + fileName);
+
+
                         if (File.Exists(fromPhoneRenewalDir + fileName))
-                        {
                             File.Move(fromPhoneRenewalDir + fileName, fromPhoneRenewalRejectedDir + fileName);
-                        }
+
                     }
                 }
             }
@@ -335,7 +340,7 @@ namespace OpenImis.ModulesV3.PolicyModule.Repositories
         {
             var helper = new SelfRenewalHelper(_configuration, _hostingEnvironment, _loggerFactory);
             var response = await helper.CreateSelfRenewal(renewal);
-            
+
             return response;
         }
     }


### PR DESCRIPTION
Delete the file if it already exists in the rejected folder before moving

https://openimis.atlassian.net/browse/OTC-598