### PR TITLE
OTC-612: Changed way photo paths are built

### DIFF
--- a/OpenImis.ModulesV2/InsureeModule/Repositories/InsureeRepository.cs
+++ b/OpenImis.ModulesV2/InsureeModule/Repositories/InsureeRepository.cs
@@ -130,7 +130,7 @@ namespace OpenImis.ModulesV2.InsureeModule.Repositories
                                     DOB = I.Dob.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
                                     Gender = G.Gender,
                                     InsureeName = I.LastName + " " + I.OtherNames,
-                                    PhotoPath = P.PhotoFolder + P.PhotoFileName
+                                    PhotoPath = System.IO.Path.Combine(P.PhotoFolder, P.PhotoFileName)
                                 })
                              .FirstOrDefault();
                 }

--- a/OpenImis.ModulesV3/InsureeModule/InsureeModule.cs
+++ b/OpenImis.ModulesV3/InsureeModule/InsureeModule.cs
@@ -44,7 +44,7 @@ namespace OpenImis.ModulesV3.InsureeModule
         {
             if (_insureeLogic == null)
             {
-                _insureeLogic = new InsureeLogic(_configuration);
+                _insureeLogic = new InsureeLogic(_configuration, _loggerFactory);
             }
             return _insureeLogic;
         }

--- a/OpenImis.ModulesV3/InsureeModule/Logic/FamilyLogic.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Logic/FamilyLogic.cs
@@ -35,7 +35,11 @@ namespace OpenImis.ModulesV3.InsureeModule.Logic
             {
                 foreach (var insure in response.Insurees)
                 {
-                    insure.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(_configuration.GetValue<string>("AppSettings:UpdatedFolder"), insure.PhotoPath);
+                    insure.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(
+                        _configuration.GetValue<string>("AppSettings:UpdatedFolder"), 
+                        insure.PhotoPath,
+                        _loggerFactory.CreateLogger<FamilyLogic>()
+                        );
                 }
             }
 

--- a/OpenImis.ModulesV3/InsureeModule/Logic/InsureeLogic.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Logic/InsureeLogic.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using OpenImis.ModulesV3.InsureeModule.Models;
 using OpenImis.ModulesV3.InsureeModule.Repositories;
 using OpenImis.ModulesV3.Utils;
@@ -11,10 +12,12 @@ namespace OpenImis.ModulesV3.InsureeModule.Logic
     {
         private IConfiguration _configuration;
         protected IInsureeRepository insureeRepository;
+        private readonly ILoggerFactory _loggerFactory;
 
-        public InsureeLogic(IConfiguration configuration)
+        public InsureeLogic(IConfiguration configuration, ILoggerFactory loggerFactory)
         {
             _configuration = configuration;
+            _loggerFactory = loggerFactory;
 
             insureeRepository = new InsureeRepository(_configuration);
         }
@@ -27,7 +30,11 @@ namespace OpenImis.ModulesV3.InsureeModule.Logic
 
             if (response != null)
             {
-                response.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(_configuration.GetValue<string>("AppSettings:UpdatedFolder"), response.PhotoPath);
+                response.PhotoBase64 = PhotoUtils.CreateBase64ImageFromFilepath(
+                    _configuration.GetValue<string>("AppSettings:UpdatedFolder"), 
+                    response.PhotoPath,
+                    _loggerFactory.CreateLogger<InsureeLogic>()
+                    );
             }
 
             return response;

--- a/OpenImis.ModulesV3/InsureeModule/Models/InsureeModel.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Models/InsureeModel.cs
@@ -99,7 +99,10 @@ namespace OpenImis.ModulesV3.InsureeModule.Models
 
             if (tblInsuree.Photo != null)
             {
-                insuree.PhotoPath = tblInsuree.Photo.PhotoFileName;
+                insuree.PhotoPath = System.IO.Path.Combine(
+                    tblInsuree.Photo.PhotoFolder != null ? tblInsuree.Photo.PhotoFolder : "",
+                    tblInsuree.Photo.PhotoFileName
+                );
             }
 
             return insuree;

--- a/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
@@ -57,7 +57,8 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
 
                                     response.InsureeName = string.Join(' ', reader["OtherNames"].ToString()) + ' ' + reader["LastName"].ToString();
                                     response.CHFID = reader["CHFID"].ToString();
-                                    response.PhotoPath = reader["PhotoPath"].ToString();
+                                    response.PhotoPath = System.IO.Path.Combine(reader["PhotoPath"].ToString()
+                                        .Split(new[] { "\\" }, StringSplitOptions.None));
                                     response.DOB = reader["DOB"].ToString().ToNullableDatetime();
                                     response.Gender = reader["Gender"].ToString();
                                 }
@@ -119,7 +120,7 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                                 DOB = I.Dob,
                                 Gender = G.Gender,
                                 InsureeName = I.LastName + " " + I.OtherNames,
-                                PhotoPath = P.PhotoFolder + P.PhotoFileName
+                                PhotoPath = System.IO.Path.Combine(P.PhotoFolder, P.PhotoFileName) 
                             }).FirstOrDefault();
             }
 

--- a/OpenImis.ModulesV3/OpenImis.ModulesV3.csproj
+++ b/OpenImis.ModulesV3/OpenImis.ModulesV3.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\OpenImis.Security\OpenImis.Security.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
   <ProjectExtensions><VisualStudio><UserProperties BuildVersion_StartDate="2000/1/1" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/OpenImis.ModulesV3/Utils/PhotoUtils.cs
+++ b/OpenImis.ModulesV3/Utils/PhotoUtils.cs
@@ -2,19 +2,20 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace OpenImis.ModulesV3.Utils
 {
     public static class PhotoUtils
     {
-        public static string CreateBase64ImageFromFilepath(string photoPath,string imageName)
+        public static string CreateBase64ImageFromFilepath(string photoPath,string imageName, ILogger logger=null)
         {
             var base64 = "";
             if (!string.IsNullOrEmpty(imageName))
             {
                 var startIndex = imageName.LastIndexOf("\\") == -1 ? 0 : imageName.LastIndexOf("\\");
                 var fileName = imageName.Substring(startIndex);
-                var fileFullPath = Path.Join(photoPath, fileName);
+                var fileFullPath =System.IO.Path.Combine(photoPath, imageName);
 
                 if (File.Exists(fileFullPath))
                 {


### PR DESCRIPTION
Part of [OTC-612](https://openimis.atlassian.net/browse/OTC-612). 

Photo paths are built using System.Path for compatibility with dockerized application running in linux.