### PR TITLE
Networking error on Docker Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ./
       args:
         BUILD-FLAVOUR: ${BUILD-FLAVOUR:-Release}
+      network: host
     ports:
       - 8080:80
     volumes:


### PR DESCRIPTION
Seems that docker-compose networking is not working out of the box for Docker linux environnement

This is the error we had : 

```
/usr/share/dotnet/sdk/2.1.818/NuGet.targets(123,5): error : Unable to load the service index for source https://api.nuget.org/v3/index.json. [/app/OpenImis.RestApi.csproj]
/usr/share/dotnet/sdk/2.1.818/NuGet.targets(123,5): error :   Resource temporarily unavailable [/app/OpenImis.RestApi.csproj]
ERROR: Service 'restapi' failed to build: The command '/bin/sh -c dotnet restore' returned a non-zero code: 1

```

In fact the container had no network access by default : 
```
docker run -it mcr.microsoft.com/dotnet/core/sdk:2.1 /bin/bash
root@120d45800e14:/# ping 8.8.8.8
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
--- 8.8.8.8 ping statistics ---
5 packets transmitted, 0 received, 100% packet loss, time 4081m
```

We had to change network default configuration of the docker build to define that networking is using host configuration.

Need to be tested on Windows environment as it seemed to work without this parameter on local.