### PR TITLE
Enquire functionality on mobile application does not work

### DIFF
--- a/OpenImis.DB.SqlServer/DataHelper/DataHelper.cs
+++ b/OpenImis.DB.SqlServer/DataHelper/DataHelper.cs
@@ -11,19 +11,21 @@ namespace OpenImis.DB.SqlServer.DataHelper
 {
     public class DataHelper
     {
-        private readonly string ConnectionString;
+        private readonly string _connectionString;
+        private readonly int _commandTimeout = 30;
 
         public int ReturnValue { get; set; }
 
         public DataHelper(IConfiguration configuration)
         {
-            ConnectionString = configuration["ConnectionStrings:IMISDatabase"];
+            _connectionString = configuration["ConnectionStrings:IMISDatabase"];
+            if (configuration["ConnectionSettings:CommandTimeout"] != null) _commandTimeout = Int32.Parse(configuration["ConnectionSettings:CommandTimeout"]);
         }
 
         public DataSet FillDataSet(string SQL, SqlParameter[] parameters, CommandType commandType)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType, CommandTimeout = _commandTimeout })
             using (var adapter = new SqlDataAdapter(command))
             {
                 DataSet ds = new DataSet();
@@ -48,8 +50,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public DataTable GetDataTable(string SQL, SqlParameter[] parameters, CommandType commandType)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType, CommandTimeout = _commandTimeout })
             using (var adapter = new SqlDataAdapter(command))
             {
                 DataTable dt = new DataTable();
@@ -67,8 +69,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public DataSet GetDataSet(string SQL, SqlParameter[] parameters, CommandType commandType)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType, CommandTimeout = _commandTimeout })
             using (var adapter = new SqlDataAdapter(command))
             {
                 DataSet ds = new DataSet();
@@ -86,8 +88,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public void Execute(string SQL, SqlParameter[] parameters, CommandType commandType)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType, CommandTimeout = _commandTimeout })
             {
                 sqlConnection.Open();
 
@@ -102,8 +104,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public async Task ExecuteAsync(string SQL, SqlParameter[] parameters, CommandType commandType)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(SQL, sqlConnection) { CommandType = commandType, CommandTimeout = _commandTimeout })
             {
                 if (command.Connection.State == 0)
                 {
@@ -121,8 +123,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public ProcedureOutPut Procedure(string StoredProcedure, SqlParameter[] parameters, int tableIndex = 0)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure, CommandTimeout = _commandTimeout })
             using (var adapter = new SqlDataAdapter(command))
             {
                 DataSet dt = new DataSet();
@@ -155,8 +157,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public IList<SqlParameter> ExecProcedure(string StoredProcedure, SqlParameter[] parameters)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure, CommandTimeout = _commandTimeout })
             {
                 SqlParameter returnParameter = new SqlParameter("@RV", SqlDbType.Int);
                 returnParameter.Direction = ParameterDirection.ReturnValue;
@@ -181,8 +183,8 @@ namespace OpenImis.DB.SqlServer.DataHelper
 
         public async Task<IList<SqlParameter>> ExecProcedureAsync(string StoredProcedure, SqlParameter[] parameters)
         {
-            using (var sqlConnection = new SqlConnection(ConnectionString))
-            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure })
+            using (var sqlConnection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand(StoredProcedure, sqlConnection) { CommandType = CommandType.StoredProcedure, CommandTimeout = _commandTimeout })
             {
                 SqlParameter returnParameter = new SqlParameter("@RV", SqlDbType.Int);
                 returnParameter.Direction = ParameterDirection.ReturnValue;

--- a/OpenImis.DB.SqlServer/ImisDB.cs
+++ b/OpenImis.DB.SqlServer/ImisDB.cs
@@ -1,13 +1,29 @@
 ﻿using System;
+using System.Data;
+using System.Data.Common;
 using System.IO;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Configuration;
 
 namespace OpenImis.DB.SqlServer
 {
     public partial class ImisDB : IMISContext
     {
+        private int _commandTimeout = 30;
+
+        public DbCommand CreateCommand()
+        {
+            var connection = Database.GetDbConnection();
+            var command = connection.CreateCommand();
+            command.CommandTimeout = _commandTimeout;
+            return command;
+        }
+
+        public void CheckConnection()
+        {
+            var connection = Database.GetDbConnection();
+            if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+        }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -19,8 +35,8 @@ namespace OpenImis.DB.SqlServer
             //.AddJsonFile("appsettings.json")
             .AddJsonFile(Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != null ? $"{path}appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")}.json" : $"{path}appsettings.Production.json", optional: false, reloadOnChange: true)
             .Build();
-
-            optionsBuilder.UseSqlServer(configuration.GetConnectionString("IMISDatabase"));
+            if (configuration["ConnectionSettings:CommandTimeout"] != null) _commandTimeout = Int32.Parse(configuration["ConnectionSettings:CommandTimeout"]);
+            optionsBuilder.UseSqlServer(configuration.GetConnectionString("IMISDatabase"), options => options.CommandTimeout(_commandTimeout));
         }
     }
 }

--- a/OpenImis.ModulesV3/ClaimModule/Repositories/ClaimRepository.cs
+++ b/OpenImis.ModulesV3/ClaimModule/Repositories/ClaimRepository.cs
@@ -76,15 +76,13 @@ namespace OpenImis.ModulesV3.ClaimModule.Repositories
 
                         var sql = "exec @RV = uspRestApiUpdateClaimFromPhone @XML, 0, @ClaimRejected OUTPUT";
 
-                        DbConnection connection = imisContext.Database.GetDbConnection();
-
-                        using (DbCommand cmd = connection.CreateCommand())
+                        using (DbCommand cmd = imisContext.CreateCommand())
                         {
                             cmd.CommandText = sql;
 
                             cmd.Parameters.AddRange(new[] { xmlParameter, returnParameter, claimRejectedParameter });
 
-                            if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+                            imisContext.CheckConnection();
 
                             using (var reader = cmd.ExecuteReader())
                             {

--- a/OpenImis.ModulesV3/FeedbackModule/Repositories/FeedbackRepository.cs
+++ b/OpenImis.ModulesV3/FeedbackModule/Repositories/FeedbackRepository.cs
@@ -96,15 +96,13 @@ namespace OpenImis.ModulesV3.FeedbackModule.Repositories
 
                     var sql = "exec @RV = uspInsertFeedback @XML";
 
-                    DbConnection connection = imisContext.Database.GetDbConnection();
-
-                    using (DbCommand cmd = connection.CreateCommand())
+                    using (DbCommand cmd = imisContext.CreateCommand())
                     {
                         cmd.CommandText = sql;
 
                         cmd.Parameters.AddRange(new[] { xmlParameter, returnParameter });
 
-                        if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+                        imisContext.CheckConnection();
 
                         using (var reader = cmd.ExecuteReader())
                         {

--- a/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/FamilyRepository.cs
@@ -218,9 +218,7 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                     "@PolicySent OUT, @PolicyImported OUT, @PolicyRejected OUT, @PolicyChanged OUT," +
                     "@PremiumSent OUT, @PremiumImported OUT, @PremiumRejected OUT";
 
-                DbConnection connection = imisContext.Database.GetDbConnection();
-
-                using (DbCommand cmd = connection.CreateCommand())
+                using (DbCommand cmd = imisContext.CreateCommand())
                 {
 
                     cmd.CommandText = sql;
@@ -230,7 +228,7 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
                                             policyImportedParameter, policyRejectedParameter, policyChangedParameter, premiumSentParameter, premiumImportedParameter,
                                             premiumRejectedParameter });
 
-                    if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+                    imisContext.CheckConnection();
 
                     using (var reader = cmd.ExecuteReader())
                     {

--- a/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
+++ b/OpenImis.ModulesV3/InsureeModule/Repositories/InsureeRepository.cs
@@ -33,16 +33,13 @@ namespace OpenImis.ModulesV3.InsureeModule.Repositories
 
                 var sql = "exec uspAPIGetCoverage @CHFID";
 
-                DbConnection connection = imisContext.Database.GetDbConnection();
-
-                using (DbCommand cmd = connection.CreateCommand())
+                using (DbCommand cmd = imisContext.CreateCommand())
                 {
-
                     cmd.CommandText = sql;
 
                     cmd.Parameters.AddRange(new[] { chfidParameter });
 
-                    if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+                    imisContext.CheckConnection();
 
                     using (var reader = cmd.ExecuteReader())
                     {

--- a/OpenImis.ModulesV3/ReportModule/Repositories/ReportRepository.cs
+++ b/OpenImis.ModulesV3/ReportModule/Repositories/ReportRepository.cs
@@ -130,15 +130,13 @@ namespace OpenImis.ModulesV3.ReportModule.Repositories
 
                 var sql = "SELECT Active, Expired, Idle, Suspended FROM udfGetSnapshotIndicators(@SnapshotDate,@OfficerId)";
 
-                DbConnection connection = imisContext.Database.GetDbConnection();
-
-                using (DbCommand cmd = connection.CreateCommand())
+                using (DbCommand cmd = imisContext.CreateCommand())
                 {
                     cmd.CommandText = sql;
 
                     cmd.Parameters.AddRange(new[] { snapshotDateParameter, officerIdParameter });
 
-                    if (connection.State.Equals(ConnectionState.Closed)) connection.Open();
+                    imisContext.CheckConnection();
 
                     using (var reader = cmd.ExecuteReader())
                     {

--- a/OpenImis.RestApi/config/appsettings.Development.json.dist
+++ b/OpenImis.RestApi/config/appsettings.Development.json.dist
@@ -2,6 +2,9 @@
 	"ConnectionStrings": {
 		"IMISDatabase": "Server=Server;Database=IMIS;User ID=User;Password=Password"
 	},
+	"ConnectionSettings": {
+		"CommandTimeout": 30
+	},
 	"Logging": {
 		"IncludeScopes": false,
 		"LogLevel": {

--- a/OpenImis.RestApi/config/appsettings.Production.json.dist
+++ b/OpenImis.RestApi/config/appsettings.Production.json.dist
@@ -2,7 +2,9 @@
 	"ConnectionStrings": {
 		"IMISDatabase": "Server=Server;Database=IMIS;User ID=User;Password=Password"
 	},
-	
+	"ConnectionSettings": {
+		"CommandTimeout": 30
+	},
 	"Log4NetCore": {
 		"PropertyOverrides": [
 			{


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-659](https://openimis.atlassian.net/browse/OTC-659)

Changes:
- Added optional setting `ConnectionSettings:CommandTimeout` to appsettings
- Implemented variable command timeout for `DataHelper`, `ImisDB` and for commands created with `ImisDB.CreateCommand()`
- Changed DbCommand creation to `ImisDB.CreateCommand()` in V3 repositories