### PR TITLE
OTC-674 When you enquire a CHF member you get the information of beneficiary, however no photo is displayed

### DIFF
--- a/OpenImis.ModulesV3/Utils/PhotoUtils.cs
+++ b/OpenImis.ModulesV3/Utils/PhotoUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -13,15 +14,14 @@ namespace OpenImis.ModulesV3.Utils
             var base64 = "";
             if (!string.IsNullOrEmpty(imageName))
             {
-                var startIndex = imageName.LastIndexOf("\\") == -1 ? 0 : imageName.LastIndexOf("\\");
-                var fileName = imageName.Substring(startIndex);
-                var fileFullPath = Path.Join(photoPath, fileName);
-
-                var stare = Path.Combine(photoPath, imageName);
-
-                if (File.Exists(fileFullPath))
+                var fileName = imageName.Replace('\\', '/').Split('/').Last();
+                if (!string.IsNullOrEmpty(fileName)) 
                 {
-                    base64 = Convert.ToBase64String(File.ReadAllBytes(fileFullPath));
+                    var fileFullPath = Path.Join(photoPath, fileName);
+                    if (File.Exists(fileFullPath))
+                    {
+                        base64 = Convert.ToBase64String(File.ReadAllBytes(fileFullPath));
+                    }
                 }
             }
             return base64;


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-674](https://openimis.atlassian.net/browse/OTC-674)

Changes:
- Added support for both `\` and `/` in paths in `PhotoUtils`
- Added safeguard against empty filename in `PhotoUtils`