### PR TITLE
Create new User per docker instance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ ARG BUILD-FLAVOUR=Release
 COPY . ./
 RUN dotnet publish OpenImis.RestApi/OpenImis.RestApi.csproj -c $BUILD-FLAVOUR -o out
 
+RUN useradd --uid $(shuf -i 2000-65000 -n 1) app
+USER app
+
 FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
 WORKDIR /app
 COPY --from=build-env /app/OpenImis.RestApi/out .


### PR DESCRIPTION
We encountered this issue on the containered version (we have multiple rest-api docker instances on the same linux server) : 
https://github.com/dotnet/AspNetCore.Docs/issues/19814

Tried to add the "DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE=false" as an environment variable , but it didn't work.
We instead use this method : http://blog.travisgosselin.com/configured-user-limit-inotify-instances/comment-page-1/

And add a specific user by instance.

It seemed to solve the problem for now