### PR TITLE
apt-get fails with 404 errors => use archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,10 @@ COPY ./OpenImis.RestApi/config/appsettings.json /app/config/
 COPY ./scripts/entrypoint.sh /app/
 RUN chmod a+x /app/entrypoint.sh
 COPY --from=build-env /app/OpenImis.RestApi/out .
-RUN apt-get update && apt-get install gettext -y  && rm -rf /var/lib/apt/lists/*
-
+RUN echo 'deb http://archive.debian.org/debian/ stretch main' > /etc/apt/sources.list \
+    && echo 'deb http://archive.debian.org/debian-security/ stretch/updates main' >> /etc/apt/sources.list \
+    && apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install gettext -y \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT /app/entrypoint.sh


### PR DESCRIPTION
The build process does apt-get update which fails to find Debian Stretch updates in the usual mirrors. Switching to archive allows it to continue running. This would be a security concern if we were not in the middle of migrating away from this legacy code.
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/328253/235540904-c44be4f0-a1da-47ad-95a1-9ebecd076399.png">
